### PR TITLE
refactor: use fiap-fase3-app namespaces instead nodejs-api-ddd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM node:18-alpine as base
-WORKDIR /usr/src/nodejs-api-ddd
+WORKDIR /usr/src/fiap-fase3-app
 COPY ./package.json .
 RUN npm i && npm i -g typescript
 
 FROM base as build
-WORKDIR /usr/src/nodejs-api-ddd
+WORKDIR /usr/src/fiap-fase3-app
 COPY . .
-COPY --from=base /usr/src/nodejs-api-ddd/node_modules ./node_modules
+COPY --from=base /usr/src/fiap-fase3-app/node_modules ./node_modules
 RUN tsc
 
 FROM base as prod
-WORKDIR /usr/src/nodejs-api-ddd
-COPY --from=build /usr/src/nodejs-api-ddd/dist ./dist
+WORKDIR /usr/src/fiap-fase3-app
+COPY --from=build /usr/src/fiap-fase3-app/dist ./dist
 CMD ["node", "dist/main/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: api-container
     build: .
     restart: always
-    image: nodejs-api-ddd
+    image: fiap-fase3-app
     ports:
       - "5050:5050"
     links:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodejs-api-ddd",
+  "name": "fiap-fase3-app",
   "version": "2.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodejs-api-ddd",
+      "name": "fiap-fase3-app",
       "version": "2.17.6",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodejs-api-ddd",
+  "name": "fiap-fase3-app",
   "version": "2.17.6",
   "description": "NodeJs Rest API using TDD, Clean Architecture, Typescript and Design Patterns",
   "main": "dist/main/server.js",
@@ -8,7 +8,7 @@
     "start:dev": "ts-node src/main/server.ts",
     "build": "rimraf dist && tsc -p tsconfig-build.json",
     "up": "npm run build && docker-compose up -d",
-    "up:locally": "npm run build && docker build -t nodejs-api-ddd . && docker-compose up -d",
+    "up:locally": "npm run build && docker build -t fiap-fase3-app . && docker-compose up -d",
     "down": "docker-compose down",
     "husky:prepare": "husky install",
     "lint:fix": "eslint 'src/**' --fix",

--- a/src/main/config/env.ts
+++ b/src/main/config/env.ts
@@ -1,7 +1,7 @@
 export default {
-  // MONGO_DB_URL: process.env.MONGO_DB_URL || 'mongodb://mongo:27017/nodejs-api-ddd',
+  // MONGO_DB_URL: process.env.MONGO_DB_URL || 'mongodb://mongo:27017/fiap-fase3-app',
   MONGO_DB_URL: 'mongodb+srv://gabrielvrfreire:VEzXpsUKeImteFu4@cluster0.rhhrdat.mongodb.net/?retryWrites=true&w=majority',
-  MONGO_DB_DATABASE: process.env.MONGO_DB_DADABASE || 'nodejs-api-ddd',
+  MONGO_DB_DATABASE: process.env.MONGO_DB_DADABASE || 'fiap-fase3-app',
   PORT: process.env.PORT || 5050,
   JWT_SECRET: process.env.JWT_SECRET || ';alksjdfjklajdf'
 }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -9,8 +9,3 @@ prismaClient.$connect()
     app.listen(env.PORT, () => process.stdout.write(`Server running at ${env.PORT}`))
   })
   .catch(console.error)
-
-/*
-mysql -h fiap-rds-api-db.cyjnswqfrmiw.us-east-1.rds.amazonaws.com -u admin -p
-og2m3z7W,2Yz
-*/


### PR DESCRIPTION
- use fiap-fase3-app namespaces instead nodejs-api-ddd